### PR TITLE
Upgrade yanagishima from v1 to v5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
-FROM java:8u92-jre-alpine
+FROM java:8u111-jre
 MAINTAINER szyn <aqr.aqua@gmail.com>
 
-RUN apk --no-cache add unzip openssl bash && \
-wget https://bintray.com/artifact/download/wyukawa/generic/yanagishima-1.0.zip && \
-unzip yanagishima-1.0.zip && \
-rm yanagishima-1.0.zip
+ENV VERSION=5.0
 
-WORKDIR yanagishima-1.0
+RUN apt-get update -y && apt-get install -y  unzip openssl bash && \
+wget https://bintray.com/artifact/download/wyukawa/generic/yanagishima-${VERSION}.zip && \
+unzip yanagishima-${VERSION}.zip && \
+rm yanagishima-${VERSION}.zip
+
+WORKDIR yanagishima-${VERSION}
 COPY bin/start.sh bin/start.sh
 COPY conf/yanagishima.properties conf/yanagishima.properties
 
 COPY docker-entrypoint.sh docker-entrypoint.sh
 RUN chmod +x docker-entrypoint.sh && \
-chmod +x bin/start.sh && \
-mkdir result
+chmod +x bin/start.sh
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ MAINTAINER szyn <aqr.aqua@gmail.com>
 
 ENV VERSION=5.0
 
-RUN apt-get update -y && apt-get install -y  unzip openssl bash && \
+RUN apt-get update -y && \
+apt-get install -y  unzip openssl bash && \
+apt-get clean && \
+rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* && \
 wget https://bintray.com/artifact/download/wyukawa/generic/yanagishima-${VERSION}.zip && \
 unzip yanagishima-${VERSION}.zip && \
 rm yanagishima-${VERSION}.zip

--- a/conf/yanagishima.properties
+++ b/conf/yanagishima.properties
@@ -1,6 +1,12 @@
 jetty.port=8080
-presto.coordinator.server=http://${PRESTO_COODINATOR_URL}
-presto.redirect.server=http://${PRESTO_COODINATOR_URL}
+presto.query.max-run-time-seconds=1800
+presto.max-result-file-byte-size=1073741824
+presto.datasources=your-presto
+presto.coordinator.server.your-presto=http://${PRESTO_COODINATOR_URL}
+presto.redirect.server.your-presto=http://${PRESTO_COODINATOR_URL}
+catalog.your-presto=${CATALOG}
+schema.your-presto=${SCHEMA}
 select.limit=500
-catalog=${CATALOG}
-schema=${SCHEMA}
+audit.http.header.name=some.auth.header
+to.values.query.limit=500
+check.datasource=false

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-CONF_PATH=/yanagishima-1.0/conf/yanagishima.properties
+CONF_PATH=/yanagishima-${VERSION}/conf/yanagishima.properties
 sed -i -e "s/\${PRESTO_COODINATOR_URL}/${PRESTO_COODINATOR_URL}/g" ${CONF_PATH}
 sed -i -e "s/\${CATALOG}/${CATALOG}/g" ${CONF_PATH}
 sed -i -e "s/\${SCHEMA}/${SCHEMA}/g" ${CONF_PATH}
 
-sh /yanagishima-1.0/bin/start.sh
+sh /yanagishima-${VERSION}/bin/start.sh


### PR DESCRIPTION
- upgrade yanagishima
  - use `VERSION` variables
  - change yanagishima.properties
- change base image from alpine to debian

change the base image from alpine to debian because an error related to the sqlite library occurs.

log with error on alpine image
```
Failed to load native library:sqlite-3.18.0-567815c9-80a3-4e32-aa28-4185d628f47c-libsqlitejdbc.so. osinfo: Linux/x86_64
java.lang.UnsatisfiedLinkError: /tmp/sqlite-3.18.0-567815c9-80a3-4e32-aa28-4185d628f47c-libsqlitejdbc.so: Error relocating /tmp/sqlite-3.18.0-567815c9-80a3-4e32-aa28-4185d628f47c-libsqlitejdbc.so: __isnan: symbol not found
Exception in thread "main" java.lang.UnsatisfiedLinkError: org.sqlite.core.NativeDB._open_utf8([BI)V
```